### PR TITLE
Add namespace to app build.gradle

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /build/
 /app/build/
 .gradle/
+local.properties

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -4,6 +4,7 @@ plugins {
 
 android {
     compileSdkVersion 34
+    namespace 'com.example.helloworld'
     defaultConfig {
         applicationId "com.example.helloworld"
         minSdkVersion 21

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -5,7 +5,9 @@
         android:label="HelloWorld"
         android:allowBackup="true"
         android:supportsRtl="true">
-        <activity android:name=".MainActivity">
+        <activity
+            android:name=".MainActivity"
+            android:exported="true">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
                 <category android:name="android.intent.category.LAUNCHER" />

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,0 +1,2 @@
+android.useAndroidX=true
+android.enableJetifier=true


### PR DESCRIPTION
## Summary
- add namespace line in app build.gradle per Android conventions
- enable AndroidX and Jetifier
- mark MainActivity exported to satisfy manifest requirements

## Testing
- `gradle assembleDebug`

------
https://chatgpt.com/codex/tasks/task_e_688651a69074832c8e057525b140b283